### PR TITLE
Utils pr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__
 *.swp
 octave-workspace
 *.egg
+tmp

--- a/pilco/__init__.py
+++ b/pilco/__init__.py
@@ -1,3 +1,4 @@
 from . import models
 from . import controllers
 from . import rewards
+from . import utils

--- a/pilco/utils.py
+++ b/pilco/utils.py
@@ -28,9 +28,13 @@ def reward_wrapper(reward, m, s):
 def get_induced_points(smgpr):
     return smgpr.Z
 
-def save_pilco(path, X, Y, pilco):
+def save_pilco(path, X, Y, pilco, sparse=False):
     np.savetxt(path + 'X.csv', X, delimiter=',')
     np.savetxt(path + 'Y.csv', Y, delimiter=',')
+    if sparse:
+        with open(path+ 'n_ind.txt', 'w') as f:
+            f.write('%d' % pilco.mgpr.num_induced_points)
+            f.close()
     np.save(path + 'pilco_values.npy', pilco.read_values())
     for i,m in enumerate(pilco.mgpr.models):
         np.save(path + "model_" + str(i) + ".npy", m.read_values())
@@ -41,7 +45,10 @@ def load_pilco(path, sparse=False):
     if not sparse:
         pilco = PILCO(X, Y)
     else:
-        pilco = PILCO(X, Y, num_induced_points=10)
+        with open(path+ 'n_ind.txt', 'r') as f:
+            n_ind = int(f.readline())
+            f.close()
+        pilco = PILCO(X, Y, num_induced_points=n_ind)
     params = np.load(path + "pilco_values.npy").item()
     pilco.assign(params)
     for i,m in enumerate(pilco.mgpr.models):

--- a/pilco/utils.py
+++ b/pilco/utils.py
@@ -1,0 +1,50 @@
+import numpy as np
+from gpflow import autoflow
+from gpflow import settings
+from pilco.models.pilco import PILCO
+float_type = settings.dtypes.float_type
+
+@autoflow((float_type,[None, None]), (float_type,[None, None]), (np.int32, []))
+def predict_wrapper(pilco, m, s, horizon):
+    return pilco.predict(m, s, horizon)
+
+@autoflow((float_type,[None, None]), (float_type,[None, None]))
+def predict_gpr_wrapper(mgpr, m, s):
+    return mgpr.predict_on_noisy_inputs(m, s)
+
+@autoflow((float_type,[None, None]), (float_type,[None, None]))
+def compute_action_wrapper(pilco, m, s):
+    return pilco.controller.compute_action(m, s)
+
+@autoflow((float_type,[None, None]), (float_type,[None, None]))
+def compute_action_wrapper(controller, m, s, squash=False):
+    return controller.compute_action(m, s, squash)
+
+@autoflow((float_type, [None, None]), (float_type, [None, None]))
+def reward_wrapper(reward, m, s):
+    return reward.compute_reward(m, s)
+
+@autoflow()
+def get_induced_points(smgpr):
+    return smgpr.Z
+
+def save_pilco(path, X, Y, pilco):
+    np.savetxt(path + 'X.csv', X, delimiter=',')
+    np.savetxt(path + 'Y.csv', Y, delimiter=',')
+    np.save(path + 'pilco_values.npy', pilco.read_values())
+    for i,m in enumerate(pilco.mgpr.models):
+        np.save(path + "model_" + str(i) + ".npy", m.read_values())
+
+def load_pilco(path, sparse=False):
+    X = np.loadtxt(path + 'X.csv', delimiter=',')
+    Y = np.loadtxt(path + 'Y.csv', delimiter=',')
+    if not sparse:
+        pilco = PILCO(X, Y)
+    else:
+        pilco = PILCO(X, Y, num_induced_points=10)
+    params = np.load(path + "pilco_values.npy").item()
+    pilco.assign(params)
+    for i,m in enumerate(pilco.mgpr.models):
+        values = np.load(path + "model_" + str(i) + ".npy").item()
+        m.assign(values)
+    return pilco

--- a/tests/test_cascade.py
+++ b/tests/test_cascade.py
@@ -14,13 +14,7 @@ octave.addpath(dir_path)
 
 float_type = settings.dtypes.float_type
 
-@autoflow((float_type,[None, None]), (float_type,[None, None]), (np.int32, []))
-def predict_wrapper(pilco, m, s, horizon):
-    return pilco.predict(m, s, horizon)
-
-@autoflow((float_type,[None, None]), (float_type,[None, None]))
-def compute_action_wrapper(pilco, m, s):
-    return pilco.controller.compute_action(m, s)
+from pilco.utils import predict_wrapper, compute_action_wrapper
 
 def test_cascade():
     np.random.seed(0)

--- a/tests/test_controllers.py
+++ b/tests/test_controllers.py
@@ -11,9 +11,7 @@ octave.addpath(dir_path)
 
 float_type = settings.dtypes.float_type
 
-@autoflow((float_type,[None, None]), (float_type,[None, None]))
-def compute_action_wrapper(controller, m, s, squash=False):
-    return controller.compute_action(m, s, squash)
+from pilco.utils import compute_action_wrapper
 
 def test_rbf():
     np.random.seed(0)

--- a/tests/test_load_save.py
+++ b/tests/test_load_save.py
@@ -1,0 +1,41 @@
+from pilco.models import MGPR
+from pilco.models.pilco import PILCO
+import numpy as np
+import os
+from gpflow import autoflow
+from gpflow import settings
+float_type = settings.dtypes.float_type
+
+from pilco.utils import save_pilco, load_pilco, predict_wrapper
+
+def test_load_save():
+    np.random.seed(0)
+    d = 2  # State dimenstion
+    k = 1  # Controller's output dimension
+    horizon = 10
+    e = np.array([[10.0]])   # Max control input. Set too low can lead to Cholesky failures.
+
+    # Training Dataset
+    X0 = np.random.rand(100, d + k)
+    A = np.random.rand(d + k, d)
+    Y0 = np.sin(X0).dot(A) + 1e-3*(np.random.rand(100, d) - 0.5)  #  Just something smooth
+    pilco = PILCO(X0, Y0)
+    pilco.optimize()
+
+    save_pilco("", X0, Y0, pilco)
+
+    pilco2 = load_pilco("")
+
+    m = np.random.rand(1, d)  # But MATLAB defines it as m'
+    s = np.random.rand(d, d)
+    s = s.dot(s.T)  # Make s positive semidefinite
+
+    M1, S1, r1 = predict_wrapper(pilco, m, s, 5)
+    M2, S2, r2 = predict_wrapper(pilco2, m, s, 5)
+    np.testing.assert_allclose(M1, M2, rtol=1e-6)
+    np.testing.assert_allclose(S1, S2, rtol=1e-6)
+    np.testing.assert_allclose(r1, r2, rtol=1e-6)
+
+
+if __name__=='__main__':
+    test_load_save()

--- a/tests/test_load_save.py
+++ b/tests/test_load_save.py
@@ -21,15 +21,19 @@ def test_load_save():
     Y0 = np.sin(X0).dot(A) + 1e-3*(np.random.rand(100, d) - 0.5)  #  Just something smooth
     pilco = PILCO(X0, Y0)
     pilco.optimize()
-    save_pilco("", X0, Y0, pilco)
+    try:
+        os.mkdir("tmp/")
+    except FileExistsError:
+        pass
+    save_pilco("tmp/", X0, Y0, pilco)
 
-    pilco2 = load_pilco("")
+    pilco2 = load_pilco("tmp/")
 
     pilco_sp = PILCO(X0, Y0, num_induced_points=15)
     pilco_sp.optimize()
-    save_pilco("sparse_", X0, Y0, pilco_sp, sparse=True)
+    save_pilco("tmp/sparse_", X0, Y0, pilco_sp, sparse=True)
 
-    pilco_sp2 = load_pilco("sparse_", sparse=True)
+    pilco_sp2 = load_pilco("tmp/sparse_", sparse=True)
 
     m = np.random.rand(1, d)  # But MATLAB defines it as m'
     s = np.random.rand(d, d)
@@ -47,6 +51,11 @@ def test_load_save():
     np.testing.assert_allclose(S1, S2, rtol=1e-6)
     np.testing.assert_allclose(r1, r2, rtol=1e-6)
 
+    filenames = ["X.csv", "Y.csv", "pilco_values.npy", "model_0.npy", "model_1.npy"]
+    filenames = filenames + ["sparse_" + x for x in filenames] + ["sparse_n_ind.txt"]
+    print(filenames)
+    for f in filenames:
+        os.remove("tmp/" + f)
 
 if __name__=='__main__':
     test_load_save()

--- a/tests/test_load_save.py
+++ b/tests/test_load_save.py
@@ -21,10 +21,15 @@ def test_load_save():
     Y0 = np.sin(X0).dot(A) + 1e-3*(np.random.rand(100, d) - 0.5)  #  Just something smooth
     pilco = PILCO(X0, Y0)
     pilco.optimize()
-
     save_pilco("", X0, Y0, pilco)
 
     pilco2 = load_pilco("")
+
+    pilco_sp = PILCO(X0, Y0, num_induced_points=15)
+    pilco_sp.optimize()
+    save_pilco("sparse_", X0, Y0, pilco_sp, sparse=True)
+
+    pilco_sp2 = load_pilco("sparse_", sparse=True)
 
     m = np.random.rand(1, d)  # But MATLAB defines it as m'
     s = np.random.rand(d, d)
@@ -32,6 +37,12 @@ def test_load_save():
 
     M1, S1, r1 = predict_wrapper(pilco, m, s, 5)
     M2, S2, r2 = predict_wrapper(pilco2, m, s, 5)
+    np.testing.assert_allclose(M1, M2, rtol=1e-6)
+    np.testing.assert_allclose(S1, S2, rtol=1e-6)
+    np.testing.assert_allclose(r1, r2, rtol=1e-6)
+
+    M1, S1, r1 = predict_wrapper(pilco_sp, m, s, 5)
+    M2, S2, r2 = predict_wrapper(pilco_sp2, m, s, 5)
     np.testing.assert_allclose(M1, M2, rtol=1e-6)
     np.testing.assert_allclose(S1, S2, rtol=1e-6)
     np.testing.assert_allclose(r1, r2, rtol=1e-6)

--- a/tests/test_predictions.py
+++ b/tests/test_predictions.py
@@ -10,9 +10,7 @@ octave.addpath(dir_path)
 
 float_type = settings.dtypes.float_type
 
-@autoflow((float_type,[None, None]), (float_type,[None, None]))
-def predict_wrapper(mgpr, m, s):
-    return mgpr.predict_on_noisy_inputs(m, s)
+from pilco.utils import predict_gpr_wrapper
 
 def test_predictions():
     np.random.seed(0)
@@ -32,13 +30,13 @@ def test_predictions():
     s = np.random.rand(d, d)
     s = s.dot(s.T)  # Make s positive semidefinite
 
-    M, S, V = predict_wrapper(mgpr, m, s)
+    M, S, V = predict_gpr_wrapper(mgpr, m, s)
 
     # Change the dataset and predict again. Just to make sure that we don't cache something we shouldn't.
     X0 = 5*np.random.rand(100, d)
-    mgpr.set_XY(X0, Y0) 
+    mgpr.set_XY(X0, Y0)
 
-    M, S, V = predict_wrapper(mgpr, m, s)
+    M, S, V = predict_gpr_wrapper(mgpr, m, s)
 
     # convert data to the struct expected by the MATLAB implementation
     lengthscales = np.stack([model.kern.lengthscales.value for model in mgpr.models])

--- a/tests/test_rewards.py
+++ b/tests/test_rewards.py
@@ -10,9 +10,7 @@ octave.addpath(dir_path)
 
 float_type = settings.dtypes.float_type
 
-@autoflow((float_type, [None, None]), (float_type, [None, None]))
-def reward_wrapper(reward, m, s):
-    return reward.compute_reward(m, s)
+from pilco.utils import reward_wrapper
 
 def test_reward():
     '''

--- a/tests/test_sparse_predictions.py
+++ b/tests/test_sparse_predictions.py
@@ -10,13 +10,7 @@ octave.addpath(dir_path)
 
 float_type = settings.dtypes.float_type
 
-@autoflow((float_type,[None, None]), (float_type,[None, None]))
-def predict_wrapper(smgpr, m, s):
-    return smgpr.predict_on_noisy_inputs(m, s)
-
-@autoflow()
-def get_induced_points(smgpr):
-    return smgpr.Z
+from pilco.utils import predict_gpr_wrapper, get_induced_points
 
 def test_sparse_predictions():
     np.random.seed(0)
@@ -36,7 +30,7 @@ def test_sparse_predictions():
     s = np.random.rand(d, d)
     s = s.dot(s.T)  # Make s positive semidefinite
 
-    M, S, V = predict_wrapper(smgpr, m, s)
+    M, S, V = predict_gpr_wrapper(smgpr, m, s)
 
     # convert data to the struct expected by the MATLAB implementation
     lengthscales = np.stack([model.kern.lengthscales.value for model in smgpr.models])


### PR DESCRIPTION
This is a small pr, to add a save and a load utility function for pilco. This will allow a model to be stored, and be loaded later, to resume training, test further etc. I also moved all wrappers to a new file, utils.py, along with the save and load function, so that they can be imported whenever needed. The new functions are tested, so I consider it safe to merge, even though it might be possible to have the same functionality in a more elegant way (if for example we can get gpflow.saver to work as in [here](https://github.com/GPflow/GPflow/issues/753))