### PR TITLE
Speed up the policy optimization by @tf.function

### DIFF
--- a/pilco/models/pilco.py
+++ b/pilco/models/pilco.py
@@ -115,6 +115,7 @@ class PILCO(gpflow.models.BayesianModel):
     def compute_action(self, x_m):
         return self.controller.compute_action(x_m, tf.zeros([self.state_dim, self.state_dim], float_type))[0]
 
+    @tf.function
     def predict(self, m_x, s_x, n):
         loop_vars = [
             tf.constant(0, tf.int32),

--- a/pilco/rewards.py
+++ b/pilco/rewards.py
@@ -16,6 +16,7 @@ class ExponentialReward(Module):
         else:
             self.t = Parameter(np.zeros((1, state_dim)), trainable=False)
 
+    @tf.function
     def compute_reward(self, m, s):
         '''
         Reward function, calculating mean and variance of rewards, given


### PR DESCRIPTION
Using @tf.function allowed for at 2-3 times speedup of policy optimization (longest step) on 'Pendulum-v0' environment. This works by pre-compiling the tensorflow graph on first execution of the function. Please let me know if you need more careful speedup analysis.